### PR TITLE
Make mona go dependency aware.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/davidsbond/mona/internal/command"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/davidsbond/mona/internal/files"
 	"github.com/urfave/cli"
 )
@@ -12,8 +13,8 @@ func Build() cli.Command {
 	return cli.Command{
 		Name:  "build",
 		Usage: "Builds any modified modules within the project",
-		Action: withProject(func(ctx *cli.Context, pj *files.ProjectFile) error {
-			return command.Build(pj)
+		Action: withModAndProject(func(ctx *cli.Context, mod deps.Module, pj *files.ProjectFile) error {
+			return command.Build(mod, pj)
 		}),
 	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,9 @@
 package cmd
 
 import (
+	"path/filepath"
+
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/davidsbond/mona/internal/files"
 	"github.com/urfave/cli"
 )
@@ -11,24 +14,47 @@ type (
 	// The ActionFunc type is a method that takes a CLI context and the
 	// current project as an argument and returns a single error.
 	ActionFunc func(ctx *cli.Context, p *files.ProjectFile) error
+	// The BuildActionFunc type is same as ActionFunc, but it also takes
+	// go module config as an argument.
+	BuildActionFunc func(ctx *cli.Context, mod deps.Module, p *files.ProjectFile) error
 )
 
 func withProject(fn ActionFunc) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
-		wd := ctx.GlobalString("wd")
-
-		root, err := files.GetProjectRoot(wd)
-
-		if err != nil {
-			return err
-		}
-
-		project, err := files.LoadProjectFile(root)
-
+		_, project, err := getRootAndProject(ctx)
 		if err != nil {
 			return err
 		}
 
 		return fn(ctx, project)
 	}
+}
+
+func withModAndProject(fn BuildActionFunc) cli.ActionFunc {
+	return func(ctx *cli.Context) error {
+		root, project, err := getRootAndProject(ctx)
+		if err != nil {
+			return err
+		}
+
+		mod, err := deps.ParseModule(filepath.Join(root, "go.mod"))
+		if err != nil {
+			return err
+		}
+
+		return fn(ctx, mod, project)
+	}
+}
+
+func getRootAndProject(ctx *cli.Context) (root string, project *files.ProjectFile, err error) {
+	wd := ctx.GlobalString("wd")
+
+	root, err = files.GetProjectRoot(wd)
+	if err != nil {
+		return "", nil, err
+	}
+
+	project, err = files.LoadProjectFile(root)
+
+	return root, project, err
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"github.com/apex/log"
 
-	"github.com/davidsbond/mona/internal/files"
-
 	"github.com/davidsbond/mona/internal/command"
+	"github.com/davidsbond/mona/internal/deps"
+	"github.com/davidsbond/mona/internal/files"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +15,8 @@ func Diff() cli.Command {
 	return cli.Command{
 		Name:  "diff",
 		Usage: "Outputs all modules where changes are detected",
-		Action: withProject(func(ctx *cli.Context, pj *files.ProjectFile) error {
-			build, test, lint, err := command.Diff(pj)
+		Action: withModAndProject(func(ctx *cli.Context, mod deps.Module, pj *files.ProjectFile) error {
+			build, test, lint, err := command.Diff(mod, pj)
 
 			if err != nil {
 				return err

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/davidsbond/mona/internal/command"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/davidsbond/mona/internal/files"
 	"github.com/urfave/cli"
 )
@@ -11,8 +12,8 @@ func Lint() cli.Command {
 	return cli.Command{
 		Name:  "lint",
 		Usage: "Lints any new/modified modules",
-		Action: withProject(func(ctx *cli.Context, pj *files.ProjectFile) error {
-			return command.Lint(pj)
+		Action: withModAndProject(func(ctx *cli.Context, mod deps.Module, pj *files.ProjectFile) error {
+			return command.Lint(mod, pj)
 		}),
 	}
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/davidsbond/mona/internal/command"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/davidsbond/mona/internal/files"
 	"github.com/urfave/cli"
 )
@@ -11,8 +12,8 @@ func Test() cli.Command {
 	return cli.Command{
 		Name:  "test",
 		Usage: "Runs tests for all modules that have been created/changed since the last test run",
-		Action: withProject(func(ctx *cli.Context, pj *files.ProjectFile) error {
-			return command.Test(pj)
+		Action: withModAndProject(func(ctx *cli.Context, mod deps.Module, pj *files.ProjectFile) error {
+			return command.Test(mod, pj)
 		}),
 	}
 }

--- a/internal/command/build.go
+++ b/internal/command/build.go
@@ -4,14 +4,15 @@ import (
 	"context"
 
 	"github.com/apex/log"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/davidsbond/mona/internal/environment"
 	"github.com/davidsbond/mona/internal/files"
 )
 
 // Build will execute the build commands for all modules where changes
 // are detected.
-func Build(pj *files.ProjectFile) error {
-	return rangeChangedModules(pj, buildModule, changeTypeBuild)
+func Build(mod deps.Module, pj *files.ProjectFile) error {
+	return rangeChangedModules(mod, pj, buildModule, changeTypeBuild)
 }
 
 func buildModule(module *files.ModuleFile) error {

--- a/internal/command/build_test.go
+++ b/internal/command/build_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/davidsbond/mona/internal/command"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +30,7 @@ func TestBuild(t *testing.T) {
 			defer deleteModuleFiles(t, tc.ModuleDirs...)
 			defer deleteProjectFiles(t)
 
-			if err := command.Build(pj); err != nil {
+			if err := command.Build(deps.Module{}, pj); err != nil {
 				assert.Fail(t, err.Error())
 				return
 			}

--- a/internal/command/diff.go
+++ b/internal/command/diff.go
@@ -1,22 +1,25 @@
 package command
 
-import "github.com/davidsbond/mona/internal/files"
+import (
+	"github.com/davidsbond/mona/internal/deps"
+	"github.com/davidsbond/mona/internal/files"
+)
 
 // Diff outputs the names of all modules where changes are detected.
-func Diff(pj *files.ProjectFile) ([]string, []string, []string, error) {
-	build, err := getChangedModules(pj, changeTypeBuild)
+func Diff(mod deps.Module, pj *files.ProjectFile) ([]string, []string, []string, error) {
+	build, err := getChangedModules(mod, pj, changeTypeBuild)
 
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	test, err := getChangedModules(pj, changeTypeTest)
+	test, err := getChangedModules(mod, pj, changeTypeTest)
 
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	lint, err := getChangedModules(pj, changeTypeLint)
+	lint, err := getChangedModules(mod, pj, changeTypeLint)
 
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/command/diff_test.go
+++ b/internal/command/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/davidsbond/mona/internal/command"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +29,7 @@ func TestDiff(t *testing.T) {
 			defer deleteProjectFiles(t)
 			defer deleteModuleFiles(t, tc.ModuleDirs...)
 
-			build, test, lint, err := command.Diff(pj)
+			build, test, lint, err := command.Diff(deps.Module{}, pj)
 
 			if err != nil {
 				assert.Fail(t, err.Error())

--- a/internal/command/lint.go
+++ b/internal/command/lint.go
@@ -4,14 +4,15 @@ import (
 	"context"
 
 	"github.com/apex/log"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/davidsbond/mona/internal/environment"
 	"github.com/davidsbond/mona/internal/files"
 )
 
 // Lint iterates over all new/modified modules and executes their lint command. Once complete,
 // the lint hash is updated in the lock file.
-func Lint(pj *files.ProjectFile) error {
-	return rangeChangedModules(pj, lintModule, changeTypeLint)
+func Lint(mod deps.Module, pj *files.ProjectFile) error {
+	return rangeChangedModules(mod, pj, lintModule, changeTypeLint)
 }
 
 func lintModule(module *files.ModuleFile) error {

--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 
 	"github.com/apex/log"
+	"github.com/davidsbond/mona/internal/deps"
 	"github.com/davidsbond/mona/internal/environment"
 	"github.com/davidsbond/mona/internal/files"
 )
 
 // Test attempts to run the test command for all modules where changes
 // are detected.
-func Test(pj *files.ProjectFile) error {
-	return rangeChangedModules(pj, testModule, changeTypeTest)
+func Test(mod deps.Module, pj *files.ProjectFile) error {
+	return rangeChangedModules(mod, pj, testModule, changeTypeTest)
 }
 
 func testModule(module *files.ModuleFile) error {

--- a/internal/deps/app.go
+++ b/internal/deps/app.go
@@ -1,0 +1,50 @@
+package deps
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type Deps struct {
+	Internal []string
+	External []string
+}
+
+func GetForApp(mod Module, appPath string) (deps Deps, err error) {
+	cmd := exec.Command("go", "list", "-f", `'{{ join .Deps "\n" }}'`, appPath)
+	buf := &bytes.Buffer{}
+
+	cmd.Stdout = buf
+	if err := cmd.Run(); err != nil {
+		return deps, err
+	}
+
+	allDeps := make([]string, 0)
+	for {
+		line, err := buf.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return deps, err
+		}
+		allDeps = append(allDeps, strings.TrimSpace(line))
+	}
+	seen := make(map[string]bool)
+	for _, dep := range allDeps {
+		if strings.HasPrefix(dep, mod.Name) {
+			deps.Internal = append(deps.Internal, strings.TrimPrefix(dep, mod.Name+"/"))
+			continue
+		}
+		for m, v := range mod.Deps {
+			if strings.HasPrefix(dep, m) && !seen[m] {
+				deps.External = append(deps.External, m+"@"+v)
+				seen[m] = true
+				break
+			}
+		}
+	}
+	return deps, nil
+}

--- a/internal/deps/modules.go
+++ b/internal/deps/modules.go
@@ -1,0 +1,58 @@
+package deps
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+)
+
+type Module struct {
+	Name string
+	// Deps is a map of dependency to its version
+	Deps map[string]string
+}
+
+func ParseModule(moduleFile string) (mod Module, err error) {
+	f, err := os.Open(moduleFile)
+	if err != nil {
+		return mod, err
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+
+	// Read module name
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return mod, err
+	}
+	mod.Name = strings.TrimPrefix(strings.TrimSpace(line), "module ")
+	mod.Deps = make(map[string]string)
+
+	// Read dependencies
+	readingDeps := false
+	for {
+		line, err = r.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return mod, nil
+			}
+			return mod, err
+		}
+		if line == "require (\n" || line == ")\n" {
+			// Star stop processing dependencies
+			readingDeps = !readingDeps
+			continue
+		}
+
+		if readingDeps && !strings.Contains(line, "// indirect") {
+			// We ignore indirect dependencies
+			line = strings.TrimSpace(line)
+			parts := strings.Split(line, " ")
+			mod.Deps[parts[0]] = parts[1]
+			// TODO: need to deal with replace and edit,
+			//  might be better to use some go tooling
+		}
+	}
+}

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -1,0 +1,41 @@
+package hash
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"sort"
+
+	"github.com/davidsbond/mona/internal/deps"
+	"github.com/davidsbond/mona/pkg/hashdir"
+)
+
+func GetForApp(mod deps.Module, appPath string, excludes ...string) (string, error) {
+	appDeps, err := deps.GetForApp(mod, appPath)
+	if err != nil {
+		return "", err
+	}
+	sort.Sort(sort.StringSlice(appDeps.Internal))
+	sort.Sort(sort.StringSlice(appDeps.External))
+
+	hash := md5.New()
+	for _, dep := range appDeps.External {
+		if _, err := hash.Write([]byte(dep)); err != nil {
+			return "", err
+		}
+	}
+
+	for _, dep := range appDeps.Internal {
+		depHash, err := hashdir.Generate(dep, excludes...)
+		if err != nil {
+			return "", err
+		}
+		if _, err := hash.Write(depHash); err != nil {
+			return "", err
+		}
+		// Exclude current dependency going forward to avoid
+		// rehashing the same directory over and over.
+		excludes = append(excludes, dep)
+	}
+
+	return base64.StdEncoding.EncodeToString(hash.Sum(nil)), nil
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/davidsbond/mona/internal/deps"
+)
+
+func main() {
+	m, err := deps.ParseModule("../go.mod")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Module:", m.Name)
+	for k, v := range m.Deps {
+		fmt.Println("\t", k, "=>", v)
+	}
+
+	deps, err := deps.GetForApp(m, "../")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Internal:")
+	for _, v := range deps.Internal {
+		fmt.Println("\t", v)
+	}
+	fmt.Println("External:")
+	for _, v := range deps.External {
+		fmt.Println("\t", v)
+	}
+}

--- a/pkg/hashdir/hashdir.go
+++ b/pkg/hashdir/hashdir.go
@@ -3,7 +3,6 @@ package hashdir
 
 import (
 	"crypto/md5"
-	"encoding/base64"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,10 +10,10 @@ import (
 	"github.com/gobwas/glob"
 )
 
-// Generate creates a new hash for a given path. The path is walked and a hash is
+// GenerateString creates a new hash for a given path. The path is walked and a hash is
 // created based on all files found in the path. If a file matches one specified in
 // the 'excludes' parameter it is not used to generate the hash.
-func Generate(location string, excludes ...string) (string, error) {
+func Generate(location string, excludes ...string) ([]byte, error) {
 	hash := md5.New()
 	globs := make(map[string]glob.Glob)
 
@@ -63,8 +62,8 @@ func Generate(location string, excludes ...string) (string, error) {
 	})
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return base64.StdEncoding.EncodeToString(hash.Sum(nil)), nil
+	return hash.Sum(nil), nil
 }

--- a/pkg/hashdir/hashdir_test.go
+++ b/pkg/hashdir/hashdir_test.go
@@ -16,7 +16,7 @@ func TestGenerate(t *testing.T) {
 		Expected  string
 	}{
 		{
-			Name:      "It should generate a base64 hash of a directory",
+			Name:      "It should generate a hash of a directory",
 			Directory: "./testdir",
 			Expected:  "XrY7u+Ae7tCTyyK7j1rNww==",
 		},
@@ -34,11 +34,7 @@ func TestGenerate(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, tc.Expected, hash)
-
-			if _, err := base64.StdEncoding.Decode(make([]byte, 1024), []byte(hash)); err != nil {
-				assert.Fail(t, err.Error())
-			}
+			assert.Equal(t, tc.Expected, base64.StdEncoding.EncodeToString(hash))
 		})
 	}
 }


### PR DESCRIPTION
Currently with directory structure like this
```
app1
app2
commonDep
```
changes in the `commonDep` directory, that is a common dependency of both `app1` and `app2`,  doesn't trigger rebuild of these apps. This is just an initial POC, that fixes this issue for go projects. It also makes sure that apps are rebuilt even when the version of an external dependency is updated.

The way I've coded the changes tie this tool to go, which is all I need, but you might have other intentions. You can probably make it work for a project in any language it would just be much more work 😅  

It would also be nice to rename module to app or something else as it gets a bit confusing with go modules in the mix as well 😅 